### PR TITLE
解决二维码登录异常问题，更换新版web登录api

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -133,8 +133,8 @@ pub async fn login(method: LoginMethod) {
             }
         }
         LoginMethod::QRCODE => {
-            let (qr_data, oauth) = network::get_qr_data(&config).await;
-            let code = QrCode::new(&qr_data).unwrap();
+            let (qr_url, qrcode_key) = network::get_qr_data(&config).await;
+            let code = QrCode::new(&qr_url).unwrap();
             let image = code
                 .render::<qrcode::render::unicode::Dense1x2>()
                 .dark_color(qrcode::render::unicode::Dense1x2::Dark)
@@ -142,12 +142,12 @@ pub async fn login(method: LoginMethod) {
                 .build();
             println!("{}", image);
             log.success("二维码已生成，请扫描二维码登录");
-            log.info(format!("如果显示错误，请手动访问：{}", qr_data));
+            log.info(format!("如果显示错误，请手动访问：{}", qr_url));
             log.loading("等待扫描...");
             let mut last_status = "NotScan";
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
-                match network::check_qr_status(&config, oauth.clone()).await {
+                match network::check_qr_status(&config, qrcode_key.clone()).await {
                     network::QRStatus::NotScan => {
                         if last_status != "NotScan" {
                             log.done();

--- a/src/lib/network.rs
+++ b/src/lib/network.rs
@@ -71,7 +71,7 @@ pub async fn get_user_info(config: &Config) -> Option<UserInfo> {
 }
 
 pub async fn get_qr_data(config: &Config) -> (String, String) {
-    let url = "https://passport.bilibili.com/qrcode/getLoginUrl";
+    let url = "https://passport.bilibili.com/x/passport-login/web/qrcode/generate";
     let mut log = paris::Logger::new();
     log.loading("加载二维码");
     let client = config.get_client();
@@ -99,14 +99,14 @@ pub async fn get_qr_data(config: &Config) -> (String, String) {
             .unwrap()
             .as_str()
             .unwrap();
-        let oauth_key = value
+        let qrcode_key = value
             .get("data")
             .unwrap()
-            .get("oauthKey")
+            .get("qrcode_key")
             .unwrap()
             .as_str()
             .unwrap();
-        (url.to_string(), oauth_key.to_string())
+        (url.to_string(), qrcode_key.to_string())
     } else {
         log.done();
         log.error("无法获取二维码数据 请检查网络");

--- a/src/lib/network.rs
+++ b/src/lib/network.rs
@@ -128,10 +128,8 @@ pub async fn check_qr_status(config: &Config, qrcode_key: String) -> QRStatus {
     let url = "https://passport.bilibili.com/x/passport-login/web/qrcode/poll";
     let mut log = paris::Logger::new();
     let client = config.get_client();
-    let mut params = HashMap::new();
-    params.insert("qrcode_key", qrcode_key.clone());
-    println!("qrcode_key:{}", &qrcode_key);
-    if let Ok(resp) = client.get(url).form(&params).send().await {
+    let url_qrcode = format!("{}?{}{}", url, "qrcode_key=", &qrcode_key);
+    if let Ok(resp) = client.get(url_qrcode).send().await {
         let value: serde_json::Value = resp.json().await.unwrap();
         let data = value.get("data").unwrap();
         let code = data.get("code").unwrap().as_i64().unwrap();


### PR DESCRIPTION
原来的二维码登录api，B站已经废弃了，会一直返回`{ code: 20000, message: '该版本已不支持当前功能，请升级新版本！' }`。
查询[公开的B站api文档](https://socialsisteryi.github.io/bilibili-API-collect/docs/login/login_action/QR.html#%E6%89%AB%E7%A0%81%E7%99%BB%E5%BD%95-web%E7%AB%AF)之后，将获取二维码和登录的api都更新了，经过运行程序恢复正常